### PR TITLE
chore: update deps to work with Laravel 12

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.0, 8.1]
+        php: [8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [7.4, 8.0, 8.1]
+        php: [8.0, 8.1]
         stability: [prefer-lowest, prefer-stable]
 
     name: P${{ matrix.php }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -1,48 +1,48 @@
 {
-  "name": "knocklabs/knockphp",
-  "description": "Knock PHP SDK",
-  "type": "library",
-  "license": "MIT",
-  "authors": [
-    {
-      "name": "Knock",
-      "email": "hello@knock.app",
-      "homepage": "https://knock.app/"
+    "name": "knocklabs/knockphp",
+    "description": "Knock PHP SDK",
+    "type": "library",
+    "license": "MIT",
+    "authors": [
+        {
+            "name": "Knock",
+            "email": "hello@knock.app",
+            "homepage": "https://knock.app/"
+        }
+    ],
+    "require": {
+        "php": "^7.4 || ^8.0",
+        "ext-json": "*",
+        "league/uri-components": "^7.5.1",
+        "php-http/client-common": "^2.5",
+        "php-http/discovery": "^1.14",
+        "php-http/httplug": "^2.3",
+        "php-http/message-factory": "^1.0",
+        "php-http/multipart-stream-builder": "^1.2",
+        "psr/http-message": "^2.0",
+        "psr/http-client-implementation": "^1.0",
+        "psr/http-factory-implementation": "^1.0"
+    },
+    "autoload": {
+        "psr-4": {
+            "Knock\\KnockSdk\\": "src/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
+    },
+    "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.8",
+        "php-http/mock-client": "^1.5",
+        "phpstan/phpstan": "^1.7",
+        "phpstan/phpstan-phpunit": "^1.1",
+        "phpunit/phpunit": "^9.5",
+        "http-interop/http-factory-guzzle": "^1.2"
     }
-  ],
-  "require": {
-    "php": "^7.4 || ^8.0",
-    "ext-json": "*",
-    "league/uri-components": "^2.4",
-    "php-http/client-common": "^2.5",
-    "php-http/discovery": "^1.14",
-    "php-http/httplug": "^2.3",
-    "php-http/message-factory": "^1.0",
-    "php-http/multipart-stream-builder": "^1.2",
-    "psr/http-message": "^1.0",
-    "psr/http-client-implementation": "^1.0",
-    "psr/http-factory-implementation": "^1.0"
-  },
-  "autoload": {
-    "psr-4": {
-      "Knock\\KnockSdk\\": "src/"
-    }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Tests\\": "tests/"
-    }
-  },
-  "config": {
-    "optimize-autoloader": true,
-    "sort-packages": true
-  },
-  "require-dev": {
-    "friendsofphp/php-cs-fixer": "^3.8",
-    "php-http/mock-client": "^1.5",
-    "phpstan/phpstan": "^1.7",
-    "phpstan/phpstan-phpunit": "^1.1",
-    "phpunit/phpunit": "^9.5",
-    "http-interop/http-factory-guzzle": "^1.2"
-  }
 }

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,10 @@
     },
     "config": {
         "optimize-autoloader": true,
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.8",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ^8.0",
+        "php": "^8.0",
         "ext-json": "*",
         "league/uri-components": "^7.5.1",
         "php-http/client-common": "^2.5",


### PR DESCRIPTION
This PR updates several dependencies to remove conflicts with Laravel 12: `league/uri-components` and `psr/http-message`, and as a result we had drop support php 7.x and 8.0.